### PR TITLE
[Forwardport] Fix adding values to system variable collection

### DIFF
--- a/app/code/Magento/Variable/Model/ResourceModel/Variable/Collection.php
+++ b/app/code/Magento/Variable/Model/ResourceModel/Variable/Collection.php
@@ -62,7 +62,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
         $this->getSelect()->join(
             ['value_table' => $this->getTable('variable_value')],
             'value_table.variable_id = main_table.variable_id',
-            ['value_table.value']
+            ['value_table.plain_value', 'value_table.html_value']
         );
         $this->addFieldToFilter('value_table.store_id', ['eq' => $this->getStoreId()]);
         return $this;

--- a/app/code/Magento/Variable/Test/Unit/Model/ResourceModel/Variable/CollectionTest.php
+++ b/app/code/Magento/Variable/Test/Unit/Model/ResourceModel/Variable/CollectionTest.php
@@ -1,0 +1,94 @@
+<?php
+/***
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\Variable\Test\Unit\Model\ResourceModel\Variable;
+
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Select;
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Variable\Model\ResourceModel\Variable\Collection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Provide tests for Variable collection class.
+ */
+class CollectionTest extends TestCase
+{
+    /**
+     * Test Collection::addValuesToResult() build correct query.
+     *
+     * @return void
+     */
+    public function testAddValuesToResult()
+    {
+        $mainTableName = 'testMainTable';
+        $tableName = 'variable_value';
+        $field = 'value_table.store_id';
+
+        $select = $this->getMockBuilder(Select::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $select->expects($this->once())
+            ->method('from')
+            ->with($this->identicalTo(['main_table' => $mainTableName]))
+            ->willReturnSelf();
+        $select->expects($this->once())
+            ->method('join')
+            ->with(
+                $this->identicalTo(['value_table' => $tableName]),
+                $this->identicalTo('value_table.variable_id = main_table.variable_id'),
+                $this->identicalTo(['value_table.plain_value', 'value_table.html_value'])
+            )->willReturnSelf();
+
+        $connection = $this->getMockBuilder(AdapterInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['select', 'prepareSqlCondition', 'quoteIdentifier'])
+            ->getMockForAbstractClass();
+        $connection->expects($this->any())
+            ->method('select')
+            ->willReturn($select);
+        $connection->expects($this->once())
+            ->method('quoteIdentifier')
+            ->with($this->identicalTo($field))
+            ->willReturn($field);
+        $connection->expects($this->once())
+            ->method('prepareSqlCondition')
+            ->with(
+                $this->identicalTo($field),
+                $this->identicalTo(['eq' => 0])
+            )->willReturn('testResultCondition');
+
+        $resource = $this->getMockBuilder(AbstractDb::class)
+            ->setMethods(['getTable', 'getMainTable', 'getConnection'])
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+        $resource->expects($this->any())
+            ->method('getConnection')
+            ->willReturn($connection);
+        $resource->expects($this->once())
+            ->method('getMainTable')
+            ->willReturn('testMainTable');
+        $resource->expects($this->exactly(2))
+            ->method('getTable')
+            ->withConsecutive(
+                [$mainTableName],
+                [$tableName]
+            )->willReturnOnConsecutiveCalls(
+                $mainTableName,
+                $tableName
+            );
+
+        $objectManager = new ObjectManager($this);
+        $collection = $objectManager->getObject(
+            Collection::class,
+            [
+                'resource' => $resource,
+            ]
+        );
+        $this->assertInstanceOf(Collection::class, $collection->addValuesToResult());
+    }
+}


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13596
Changed select fields in joined variable value table in `Magento\Variable\Model\ResourceModel\Variable\Collection#addValuesToResult()` method to match DB schema

### Description
Method mentioned above tried to select field `value` from joined `variable_value` table (which doesn't exist). I've replaced incorrect field with two proper ones: `plain_value` and `html_value`.

### Fixed Issues
Calling `Magento\Variable\Model\ResourceModel\Variable\Collection#addValuesToResult()` method results with `Zend_Db_Statement_Exception` thrown. Exception message:
```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'value_table.value' in 'field list', query was: SELECT `main_table`.*, `value_table`.`value` FROM `variable` AS `main_table`  
   INNER JOIN `variable_value` AS `value_table` ON value_table.variable_id = main_table.variable_id WHERE (`value_table`.`store_id` = 0)
```
### Manual testing scenarios
As the method is not used anywhere in the magento core there is no way to reproduce error with just clicking.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
